### PR TITLE
fix: get() should not throw exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,7 @@ $ipv4 = PublicIPv4::get(); // returns your IPv4
 $ipv6 = PublicIPv6::get(); // returns your IPv6
 $ipv4or6 = PublicIP::get(); // returns either IPv4 or IPv6
 ```
-
-[//]: # (Talk about the default configuration)
+These methods return the IP address as a `string` or `null` if the fetcher fails. No exceptions are thrown.
 
 If you want to use a specific fetcher, or a specific provider, you can use the `PublicIPv4::finder()->fetch()` method.
 
@@ -46,6 +45,7 @@ $ipv4 = PublicIPv4::finder()
         ->from(DnsProvider::OpenDNS)))
     ->fetch();
 ```
+This method gives you more control, but you will need to manage exceptions on your own.
 
 ### Advanced Usage
 

--- a/examples/ipv6.php
+++ b/examples/ipv6.php
@@ -2,6 +2,8 @@
 
 require_once __DIR__.'/../vendor/autoload.php';
 
+use KnotsPHP\PublicIP\Enums\DnsProvider;
+use KnotsPHP\PublicIP\Fetchers\DigFetcher;
 use KnotsPHP\PublicIP\Finders\PublicIPv6;
 
 echo PublicIPv6::get();

--- a/src/Abstracts/Finder.php
+++ b/src/Abstracts/Finder.php
@@ -5,6 +5,7 @@ namespace KnotsPHP\PublicIP\Abstracts;
 use KnotsPHP\PublicIP\Contracts\FetcherContract;
 use KnotsPHP\PublicIP\Contracts\FinderContract;
 use KnotsPHP\PublicIP\Enums\IpVersion;
+use KnotsPHP\PublicIP\Exceptions\Exception;
 use KnotsPHP\PublicIP\Exceptions\IpAddressNotFound;
 use KnotsPHP\PublicIP\Exceptions\NoFetcherSpecified;
 use KnotsPHP\PublicIP\Exceptions\UnmatchedIpVersionReceived;
@@ -53,8 +54,7 @@ abstract class Finder implements FinderContract
     }
 
     /**
-     * @throws IpAddressNotFound
-     * @throws NoFetcherSpecified
+     * @throws NoFetcherSpecified|UnmatchedIpVersionReceived|IpAddressNotFound
      */
     public function fetch(): ?string
     {
@@ -104,8 +104,13 @@ abstract class Finder implements FinderContract
             return $fetcher::isSupported();
         });
 
-        return (new static)
-            ->addFetchers($fetchers)
-            ->fetch();
+        try {
+            return (new static)
+                ->addFetchers($fetchers)
+                ->fetch();
+        } catch (Exception) {
+            // We ignore these exceptions, we want ::get() to be silent
+            return null;
+        }
     }
 }


### PR DESCRIPTION
Static methods in the `PublicIP::get` method of Finders should be exception-free. 
Use `fetch()` if you want to handle exceptions.