### PR TITLE
Harden GitHub Actions workflows against token disclosure

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+.github/        @SRWieZ
+.github/workflows/  @SRWieZ

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-.github/        @SRWieZ
-.github/workflows/  @SRWieZ
+/.github/ @SRWieZ

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      time: "09:00"
+      timezone: "Europe/Paris"
+    labels:
+      - "dependencies"
+      - "ci"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/pint.yml
+++ b/.github/workflows/pint.yml
@@ -1,9 +1,13 @@
 name: Linting
+
 on:
   workflow_dispatch:
   push:
     branches-ignore:
-      - 'dependabot/npm_and_yarn/*'
+      - 'dependabot/**'
+
+permissions: {}
+
 jobs:
   pint:
     runs-on: ubuntu-latest
@@ -11,10 +15,13 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          # Credentials must persist so git-auto-commit-action can push lint fixes.
+          persist-credentials: true
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2.37.1
         with:
           php-version: '8.3'
           tools: composer:v2
@@ -29,7 +36,7 @@ jobs:
         run: vendor/bin/pint
 
       - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: stefanzweifel/git-auto-commit-action@be7095c202abcf573b09f20541e0ee2f6a3a9d9b # v4.9.2
         with:
           commit_message: PHP Linting (Pint)
           skip_fetch: true

--- a/.github/workflows/pint.yml
+++ b/.github/workflows/pint.yml
@@ -2,23 +2,22 @@ name: Linting
 
 on:
   workflow_dispatch:
+  pull_request:
   push:
-    branches-ignore:
-      - 'dependabot/**'
+    branches:
+      - main
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   pint:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          # Credentials must persist so git-auto-commit-action can push lint fixes.
-          persist-credentials: true
+          persist-credentials: false
 
       - name: Setup PHP
         uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2.37.1
@@ -26,17 +25,8 @@ jobs:
           php-version: '8.3'
           tools: composer:v2
 
-      - name: Copy .env
-        run: php -r "file_exists('.env') || copy('.env.example', '.env');"
-
       - name: Install Dependencies
         run: composer install -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
 
-      - name: Launch Pint inspection
-        run: vendor/bin/pint
-
-      - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@be7095c202abcf573b09f20541e0ee2f6a3a9d9b # v4.9.2
-        with:
-          commit_message: PHP Linting (Pint)
-          skip_fetch: true
+      - name: Run Pint
+        run: vendor/bin/pint --test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}
@@ -19,10 +22,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2.37.1
         with:
           php-version: ${{ matrix.php }}
           tools: composer:v2
@@ -41,7 +46,7 @@ jobs:
           echo "dir=$dir" >> $env:GITHUB_OUTPUT
 
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ${{ steps.composer-cache-unix.outputs.dir || steps.composer-cache-windows.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/cli/publicip.php
+++ b/cli/publicip.php
@@ -4,6 +4,7 @@
 use KnotsPHP\PublicIP\Finders\PublicIP;
 use KnotsPHP\PublicIP\Finders\PublicIPv4;
 use KnotsPHP\PublicIP\Finders\PublicIPv6;
+use NunoMaduro\Collision\Provider;
 
 error_reporting(E_ALL ^ E_DEPRECATED ^ E_NOTICE);
 
@@ -12,7 +13,7 @@ if (! class_exists('\Composer\InstalledVersions')) {
 }
 
 if (class_exists('\NunoMaduro\Collision\Provider')) {
-    (new \NunoMaduro\Collision\Provider)->register();
+    (new Provider)->register();
 }
 
 $ipVersion = null;


### PR DESCRIPTION
## Why

[Composer CVE-2026-45793](https://github.com/composer/composer/security/advisories/GHSA-f9f8-rm49-7jv2) (disclosed 2026-05-13) leaked GitHub Actions `GITHUB_TOKEN` values into stderr during a ~14-hour window when Composer's token-format validator rejected GitHub's new `ghs_<id>_<base64url-JWT>` token format and printed the rejected token verbatim. GitHub's secret masker couldn't reliably redact those tokens once Symfony Console wrapped or framed them with ANSI codes.

The audit of this repo found **no workflow runs in the affected window** (2026-05-12 → 2026-05-13), so no logs need scrubbing. This PR is forward-looking hardening, applying the pattern Laravel just merged in [laravel/fortify#674](https://github.com/laravel/fortify/pull/674).

## What this PR changes

**1. Pin every action to a commit SHA** (with trailing version comment)

Tags are mutable — a maintainer-account compromise or a force-pushed `@v2` tag (cf. tj-actions/changed-files, CVE-2025-30066) silently re-routes your workflow to attacker-controlled code on the next run. SHAs are immutable.

| Action | Pin |
|---|---|
| `actions/checkout` | `34e114876b0b11c390a56381ad16ebd13914f8d5` (v4.3.1) |
| `shivammathur/setup-php` | `7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc` (v2.37.1) |
| `actions/cache` | `0057852bfaa89a56745cba8c7296529d2fc39830` (v4.3.0) |

**2. Top-level `permissions: contents: read`** on both workflows. No job needs more.

**3. `persist-credentials: false`** on every `actions/checkout`. No workflow pushes, so no credentials need to survive checkout.

**4. Switch pint workflow to `--test` mode** (was auto-commit)

Previously pint ran on every push and committed lint fixes back via `stefanzweifel/git-auto-commit-action`. That pattern has two drawbacks:

- Every contributor PR gets an extra commit by the `GITHUB_TOKEN` identity — confusing for review, breaks signed-commit policies.
- Persisting credentials on checkout (required by the auto-commit action) widens the blast radius of any later step.

The new pint workflow runs `vendor/bin/pint --test`, fails on diff, and asks contributors to run `composer pint` locally. The `stefanzweifel/git-auto-commit-action` dependency is dropped entirely (one less third-party action in the supply chain).

Trigger narrowed from "every push" to `pull_request + push to main + workflow_dispatch` to match `test.yml`.

**5. `.github/dependabot.yml`** so pinned SHAs don't rot
- **Monthly** schedule (sufficient for the GitHub Actions ecosystem; security advisories file PRs immediately regardless of schedule).
- Grouped (`patterns: ["*"]`) so all action bumps land in a single PR per month.
- Labelled `dependencies`, `ci` for easy triage.

**6. `.github/CODEOWNERS`** — `@SRWieZ` owns `/.github/` so future workflow changes require maintainer review.

## A note on the second commit (48e41a9)

When this branch was first pushed, the *old* auto-commit pint workflow was still in effect and ran one last time — it found a tiny pre-existing lint debt in `cli/publicip.php` (2 lines) and committed the fix as `48e41a9`. That fix is legitimate. Subsequent pushes to this branch no longer auto-commit because the new pint triggers only on `pull_request` and `push: main`.

## What this PR does *not* change

- **No major version bumps** of any action — all pins are within the existing major. Dependabot can propose v5/v6/v7 bumps separately.
- **Composer version pinning**: `tools: composer:v2` already pulls latest 2.x (2.9.8+), which contains the CVE fix. No explicit pin needed.

## Repo-level settings still to apply (separately, outside this PR)

- **Tag protection** on `v*` so a stolen token cannot push a malicious release tag.
- **Branch protection** on `main` requiring CODEOWNERS approval on `.github/**`.
- **Default `GITHUB_TOKEN` permissions** at repo level set to read-only (forces every workflow to explicitly opt in to writes).

Happy to apply these via `gh api` after this PR merges.

## Test plan

- [ ] `Tests` workflow green on this PR (3 OS × 2 PHP = 6 cells).
- [ ] `Linting` workflow green on this PR (Pint reports no diff after the auto-fix in 48e41a9).
- [ ] After merge, Dependabot opens its first action-update PR on the first business day of next month.

## References

- [Composer CVE-2026-45793 advisory](https://github.com/composer/composer/security/advisories/GHSA-f9f8-rm49-7jv2)
- [Packagist disclosure post](https://blog.packagist.com/composer-2-9-8-and-2-2-28-fix-github-actions-token-disclosure-in-error-messages/)
- [graycoreio writeup](https://github.com/graycoreio/github-actions-magento2/discussions/261)
- [laravel/fortify#674](https://github.com/laravel/fortify/pull/674)