### PR TITLE
Fix cpx execution

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,3 +57,10 @@ jobs:
 
       - name: Run tests
         run: ./vendor/bin/pest
+
+      - name: Test cpx execution
+        if: matrix.os == 'ubuntu-latest' && matrix.php == '8.4'
+        run: |
+          composer global require cpx/cpx --no-interaction --prefer-dist
+          export PATH="$COMPOSER_HOME/vendor/bin:$PATH"
+          cpx knotsphp/publicip:dev-${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}} --help

--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ It's recommended to install the library globally to use it in the command line.
 composer global require knotsphp/publicip
 ```
 
+Or run it without installing globally via [cpx](https://github.com/laravel/cpx):
+```bash
+cpx knotsphp/publicip
+```
+
 Then you can use the `publicip` command to get the public IP address of the current machine.
 ```bash
 # In your project directory

--- a/bin/publicip
+++ b/bin/publicip
@@ -1,10 +1,17 @@
 #!/usr/bin/env php
 <?php
 
-use KnotsPHP\PublicIP\Finders\PublicIP;
-use KnotsPHP\PublicIP\Finders\PublicIPv4;
-use KnotsPHP\PublicIP\Finders\PublicIPv6;
+$autoloadPaths = array_filter([
+    $_composer_autoload_path ?? null,
+    __DIR__.'/../vendor/autoload.php',
+    __DIR__.'/../../../autoload.php',
+]);
 
-include $_composer_autoload_path ?? __DIR__.'/../vendor/autoload.php';
+foreach ($autoloadPaths as $autoloadPath) {
+    if (is_file($autoloadPath)) {
+        require $autoloadPath;
+        break;
+    }
+}
 
 require __DIR__.'/../cli/publicip.php';


### PR DESCRIPTION
## Summary
- load Composer's vendor autoloader when the package bin is executed directly by cpx
- document cpx usage in the command-line section
- add a CI smoke test for `cpx knotsphp/publicip:dev-<branch>`

## Test Plan
- `php -l bin/publicip`
- `./vendor/bin/pint --test bin/publicip`
- `CI=true composer test`
- `cpx knotsphp/publicip:dev-fix/cpx-autoload --help`
- `cpx knotsphp/publicip:dev-fix/cpx-autoload`